### PR TITLE
build: update TypeScript config for monorepo path resolution

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,15 +8,16 @@ import { HashRouter } from 'react-router-dom'
 import { D2I18n } from 'dhis2-semis-types'
 import translation from '../locales'
 
-const Performance = ({ i18n }: { i18n: D2I18n }) => {
-    const { baseUrl } = useConfig()
+const Performance = ({ i18n, baseUrl }: { i18n: D2I18n; baseUrl?: string }) => {
+    const { baseUrl: localBaseUrl } = useConfig()
     const translate: any = i18n ? i18n : translation
+    const useBaseUrl = baseUrl || localBaseUrl
 
     return (
-        // <AppWrapper i18n={translate} baseUrl={baseUrl} dataStoreKey='dataStore/semis/values' schoolCalendarKey='dataStore/semis/schoolCalendar'>
+        // <AppWrapper i18n={translate} baseUrl={useBaseUrl} dataStoreKey='dataStore/semis/values' schoolCalendarKey='dataStore/semis/schoolCalendar'>
         //     <InitializeWrapper>
         //         <HashRouter>
-                    <Router i18n={translate} />
+                    <Router i18n={translate} baseUrl={useBaseUrl} />
         //         </HashRouter>
         //     </InitializeWrapper>
         // </AppWrapper>

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -4,10 +4,10 @@ import { Routes, Route } from 'react-router-dom';
 import WithHeaderBarLayout from '../../layout/WithHeaderBarLayout';
 import { D2I18n } from 'dhis2-semis-types';
 
-export default function Router({ i18n }: { i18n: D2I18n }) {
+export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: string }) {
     return (
         <Routes>
-            <Route path='/' element={<WithHeaderBarLayout />}>
+            <Route path='/' element={<WithHeaderBarLayout baseUrl={baseUrl} />}>
                 <Route key={'performance'} path={'/'} element={<Performance i18n={i18n} />} />
             </Route>
         </Routes>

--- a/src/layout/WithHeaderBarLayout.tsx
+++ b/src/layout/WithHeaderBarLayout.tsx
@@ -1,10 +1,8 @@
 import { Outlet } from "react-router-dom"
-import { useConfig } from "@dhis2/app-runtime"
 import useGetSelectedKeys from "../hooks/config/useGetSelectedKeys"
 import { HeaderBarLayout, SemisHeader, useSchoolCalendarKey } from "dhis2-semis-components"
 
-const WithHeaderBarLayout = () => {
-    const { baseUrl } = useConfig()
+const WithHeaderBarLayout = ({ baseUrl }: { baseUrl: string }) => {
     const schoolCalendar = useSchoolCalendarKey()
     const { program, dataStoreData } = useGetSelectedKeys()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path mappings for internal packages to enable proper module resolution within the monorepo structure. This allows TypeScript to correctly resolve imports from 'dhis2-semis-components', 'dhis2-semis-functions', and 'dhis2-semis-types' packages during compilation.