### PR TITLE
feat(marks): add select field support for LIST value types

### DIFF
--- a/src/components/marks/FieldsPerformance.tsx
+++ b/src/components/marks/FieldsPerformance.tsx
@@ -1,11 +1,11 @@
 import { format } from 'date-fns';
 import { useRecoilState } from 'recoil';
-import SimpleField from './SimpleField';
 import { useEffect, useMemo, useState } from 'react';
 import useSaveMarks from '../../hooks/marks/useSaveMarks';
 import { EnrollmentStatus, TableDataRefetch } from 'dhis2-semis-types';
 import { formatMarksToSave } from '../../utils/marks/formatMarksToPost';
 import { RulesEngine, useUploadEvents, useUrlParams } from 'dhis2-semis-functions';
+import { performanceFieldsMapping } from './performanceFieldsMapping';
 
 interface valueType extends Record<string, any> {
     enrollmentId: string
@@ -27,7 +27,7 @@ type FieldsPerformancePros = {
 export default function FieldsPerformance(props: FieldsPerformancePros) {
     const { urlParameters } = useUrlParams()
     const { programStage, schoolName } = urlParameters
-    const { dataElements, value, otherProps, program, originalData } = props;
+    const { dataElements, value, program, originalData } = props;
     const [values, setValues] = useState({ ...value })
 
     const { uploadValues } = useUploadEvents()
@@ -44,11 +44,11 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
     const [refetch, setRefetch] = useRecoilState(TableDataRefetch);
 
     useEffect(() => {
-        runRulesEngine({overrideValues: memoizedValues, overrideVariables: memoizedDataElements as any})
+        runRulesEngine({ overrideValues: memoizedValues, overrideVariables: memoizedDataElements as any })
     }, [value, newMark])
 
     const handleChange = (e: any) => {
-        const newValue = e.target.value
+        const newValue = e?.target?.value ?? e
         setNewMark(newValue)
 
         // Update the values in the state
@@ -57,10 +57,10 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
             [dataElements.id]: newValue
         }))
 
-        runRulesEngine({overrideValues: memoizedValues, overrideVariables: memoizedDataElements as any})
+        runRulesEngine({ overrideValues: memoizedValues, overrideVariables: memoizedDataElements as any })
     }
 
-    const handleBlur = async (e: any) => {
+    const handleBlur = async () => {
         if (!values?.programStageEvent) {
             const data = {
                 events: [{
@@ -114,18 +114,24 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
     }
 
     return (
-        <SimpleField
-            visible={updatedVariables[0]?.visible}
-            loading={loading}
-            error={updatedVariables[0]?.error || error}
-            success={success}
-            warning={updatedVariables[0]?.warning}
-            disabled={updatedVariables[0]?.disabled}
-            value={newMark}
-            handleBlur={handleBlur}
-            handleChange={handleChange}
-            field={updatedVariables[0]}
-            content={updatedVariables[0]?.content || ""}
-        />
-    );
+        <>
+            {
+                performanceFieldsMapping({
+                    visible: updatedVariables[0]?.visible,
+                    loading: loading,
+                    error: updatedVariables[0]?.error || error,
+                    success: success,
+                    warning: updatedVariables[0]?.warning,
+                    disabled: updatedVariables[0]?.disabled,
+                    value: newMark,
+                    handleBlur: handleBlur,
+                    handleChange: handleChange,
+                    field: updatedVariables[0],
+                    content: updatedVariables[0]?.content || "",
+                    fieldType: updatedVariables[0]?.valueType,
+                    options: updatedVariables[0]?.options?.optionSet?.options
+                })
+            }
+        </>
+    )
 }

--- a/src/components/marks/customIcons/customIcons.tsx
+++ b/src/components/marks/customIcons/customIcons.tsx
@@ -1,0 +1,75 @@
+/* ────────────────────────────── Icons ────────────────────────────── */
+
+export function ChevronIcon({ open }: { open: boolean }) {
+    return (
+        <svg
+            className={`dhis2-single-select__arrow${open ? ' dhis2-single-select__arrow--open' : ''}`}
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <polyline points="6 9 12 15 18 9" />
+        </svg>
+    );
+}
+
+export function ClearIcon() {
+    return (
+        <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+    );
+}
+
+export function CheckIcon({ visible }: { visible: boolean }) {
+    return (
+        <svg
+            className={`dhis2-single-select__option-check${!visible ? ' dhis2-single-select__option-check--hidden' : ''}`}
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <polyline points="20 6 9 17 4 12" />
+        </svg>
+    );
+}
+
+export function Error() {
+    return (
+        <svg
+            className={`dhis2-single-select__option-warning`}
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="13" />
+            <line x1="12" y1="16.5" x2="12.01" y2="16.5" />
+        </svg>
+    )
+}

--- a/src/components/marks/marksSelect/SimpleSelectField.tsx
+++ b/src/components/marks/marksSelect/SimpleSelectField.tsx
@@ -31,10 +31,6 @@ export function SingleSelect({
     handleChange,
     handleBlur,
 }: SingleSelectProps) {
-    console.log(error,
-        errorText,
-        helperText,)
-    /* ── State ── */
     const [open, setOpen] = useState(false);
     const [filter, setFilter] = useState('');
     const [highlightedIndex, setHighlightedIndex] = useState(-1);
@@ -47,6 +43,13 @@ export function SingleSelect({
     const optionsRef = useRef<HTMLUListElement>(null);
     const menuRef = useRef<HTMLDivElement>(null);
     const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const portalTargetRef = useRef<HTMLElement | null>(null);
+
+    /* ── Capture ownerDocument.body once mounted ── */
+    useEffect(() => {
+        portalTargetRef.current =
+            containerRef.current?.ownerDocument?.body ?? null;
+    }, []);
 
     /* ── Filtered options ── */
     const filtered = useMemo(() => {
@@ -89,21 +92,23 @@ export function SingleSelect({
     }, []);
 
     /* ── Select an option ── */
-    const selectOption = (value: string) => {
-        handleChange?.(value);
+    const selectOption = (optionValue: string) => {
+        handleChange?.(optionValue);
         triggerRef.current?.focus();
-    }
+    };
 
     /* ── Focus management for handleBlur ── */
     const handleContainerBlur = useCallback(
-        (e: FocusEvent<HTMLDivElement>) => {
+        (_e: FocusEvent<HTMLDivElement>) => {
             if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
 
             blurTimeoutRef.current = setTimeout(() => {
-                const activeEl = document.activeElement;
+                const ownerDoc = containerRef.current?.ownerDocument;
+                const activeEl = ownerDoc?.activeElement ?? null;
                 const inContainer =
                     containerRef.current?.contains(activeEl) ?? false;
-                const inMenu = menuRef.current?.contains(activeEl) ?? false;
+                const inMenu =
+                    menuRef.current?.contains(activeEl) ?? false;
 
                 if (!inContainer && !inMenu) {
                     handleBlur?.();
@@ -115,14 +120,16 @@ export function SingleSelect({
 
     /* ── Portal menu blur / focus ── */
     const handleMenuBlur = useCallback(
-        (e: FocusEvent<HTMLDivElement>) => {
+        (_e: FocusEvent<HTMLDivElement>) => {
             if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
 
             blurTimeoutRef.current = setTimeout(() => {
-                const activeEl = document.activeElement;
+                const ownerDoc = containerRef.current?.ownerDocument;
+                const activeEl = ownerDoc?.activeElement ?? null;
                 const inContainer =
                     containerRef.current?.contains(activeEl) ?? false;
-                const inMenu = menuRef.current?.contains(activeEl) ?? false;
+                const inMenu =
+                    menuRef.current?.contains(activeEl) ?? false;
 
                 if (!inContainer && !inMenu) {
                     closeMenu();
@@ -140,33 +147,45 @@ export function SingleSelect({
     /* ── Click outside ── */
     useEffect(() => {
         if (!open) return;
+
+        const ownerDoc = containerRef.current?.ownerDocument;
+        if (!ownerDoc) return;
+
         const handler = (e: MouseEvent) => {
             const target = e.target as Node;
-            const inContainer = containerRef.current?.contains(target) ?? false;
+            const inContainer =
+                containerRef.current?.contains(target) ?? false;
             const inMenu = menuRef.current?.contains(target) ?? false;
 
             if (!inContainer && !inMenu) {
                 closeMenu();
             }
         };
-        document.addEventListener('mousedown', handler);
-        return () => document.removeEventListener('mousedown', handler);
+
+        ownerDoc.addEventListener('mousedown', handler);
+        return () => ownerDoc.removeEventListener('mousedown', handler);
     }, [open, closeMenu]);
 
-    /* ── Position menu on open and reposition on scroll/resize ── */
+    /* ── Position menu on open ── */
     useLayoutEffect(() => {
         if (!open) return;
         updateMenuPosition();
     }, [open, updateMenuPosition]);
 
+    /* ── Reposition on scroll / resize ── */
     useEffect(() => {
         if (!open) return;
+
+        const ownerWin =
+            containerRef.current?.ownerDocument?.defaultView;
+        if (!ownerWin) return;
+
         const reposition = () => updateMenuPosition();
-        window.addEventListener('scroll', reposition, true);
-        window.addEventListener('resize', reposition);
+        ownerWin.addEventListener('scroll', reposition, true);
+        ownerWin.addEventListener('resize', reposition);
         return () => {
-            window.removeEventListener('scroll', reposition, true);
-            window.removeEventListener('resize', reposition);
+            ownerWin.removeEventListener('scroll', reposition, true);
+            ownerWin.removeEventListener('resize', reposition);
         };
     }, [open, updateMenuPosition]);
 
@@ -200,7 +219,11 @@ export function SingleSelect({
                     }
                     setHighlightedIndex((prev) => {
                         let next = prev + 1;
-                        while (next < filtered.length && filtered[next].disabled) next++;
+                        while (
+                            next < filtered.length &&
+                            filtered[next].disabled
+                        )
+                            next++;
                         return next < filtered.length ? next : prev;
                     });
                     break;
@@ -223,7 +246,10 @@ export function SingleSelect({
                     if (!open) {
                         e.preventDefault();
                         openMenu();
-                    } else if (highlightedIndex >= 0 && filtered[highlightedIndex]) {
+                    } else if (
+                        highlightedIndex >= 0 &&
+                        filtered[highlightedIndex]
+                    ) {
                         e.preventDefault();
                         if (!filtered[highlightedIndex].disabled) {
                             selectOption(filtered[highlightedIndex].value);
@@ -259,7 +285,15 @@ export function SingleSelect({
                     break;
             }
         },
-        [disabled, open, openMenu, closeMenu, filtered, highlightedIndex, selectOption],
+        [
+            disabled,
+            open,
+            openMenu,
+            closeMenu,
+            filtered,
+            highlightedIndex,
+            selectOption,
+        ],
     );
 
     /* ── Build class names ── */
@@ -281,79 +315,90 @@ export function SingleSelect({
         .join(' ');
 
     /* ── Dropdown menu rendered via Portal ── */
-    const dropdownMenu = open
-        ? createPortal(
-            <div
-                ref={menuRef}
-                className={`dhis2-single-select__menu${dense ? ' dhis2-single-select__menu--dense' : ''}`}
-                style={menuStyle}
-                role="presentation"
-                onBlur={handleMenuBlur}
-                onFocus={handleMenuFocus}
-                onKeyDown={handleKeyDown}
-            >
-                {/* Search input */}
-                {filterable && (
-                    <div className="dhis2-single-select__search">
-                        <input
-                            ref={searchRef}
-                            type="text"
-                            className="dhis2-single-select__search-input"
-                            placeholder={filterPlaceholder}
-                            value={filter}
-                            onChange={(e) => {
-                                setFilter(e.target.value);
-                                setHighlightedIndex(-1);
-                            }}
-                            autoComplete="off"
-                        />
-                    </div>
-                )}
+    const portalTarget = portalTargetRef.current;
 
-                {/* Options list */}
-                <ul
-                    ref={optionsRef}
-                    className="dhis2-single-select__options"
-                    role="listbox"
-                >
-                    {filtered.length === 0 ? (
-                        <li className="dhis2-single-select__empty">{noMatchText}</li>
-                    ) : (
-                        filtered.map((option, index) => {
-                            const isSelected = option.value === value;
-                            const isHighlighted = index === highlightedIndex;
-                            const optCls = [
-                                'dhis2-single-select__option',
-                                isSelected && 'dhis2-single-select__option--selected',
-                                isHighlighted && 'dhis2-single-select__option--highlighted',
-                                option.disabled && 'dhis2-single-select__option--disabled',
-                            ]
-                                .filter(Boolean)
-                                .join(' ');
+    const dropdownMenu =
+        open && portalTarget
+            ? createPortal(
+                  <div
+                      ref={menuRef}
+                      className={`dhis2-single-select__menu${dense ? ' dhis2-single-select__menu--dense' : ''}`}
+                      style={menuStyle}
+                      role="presentation"
+                      onBlur={handleMenuBlur}
+                      onFocus={handleMenuFocus}
+                      onKeyDown={handleKeyDown}
+                  >
+                      {filterable && (
+                          <div className="dhis2-single-select__search">
+                              <input
+                                  ref={searchRef}
+                                  type="text"
+                                  className="dhis2-single-select__search-input"
+                                  placeholder={filterPlaceholder}
+                                  value={filter}
+                                  onChange={(e) => {
+                                      setFilter(e.target.value);
+                                      setHighlightedIndex(-1);
+                                  }}
+                                  autoComplete="off"
+                              />
+                          </div>
+                      )}
 
-                            return (
-                                <li
-                                    key={option.value}
-                                    className={optCls}
-                                    role="option"
-                                    aria-selected={isSelected}
-                                    onMouseEnter={() => setHighlightedIndex(index)}
-                                    onMouseLeave={() => setHighlightedIndex(-1)}
-                                    onClick={() => {
-                                        selectOption(option.value);
-                                    }}
-                                >
-                                    <CheckIcon visible={isSelected} />
-                                    {option.label}
-                                </li>
-                            );
-                        })
-                    )}
-                </ul>
-            </div>,
-            document.body,
-        )
-        : null;
+                      <ul
+                          ref={optionsRef}
+                          className="dhis2-single-select__options"
+                          role="listbox"
+                      >
+                          {filtered.length === 0 ? (
+                              <li className="dhis2-single-select__empty">
+                                  {noMatchText}
+                              </li>
+                          ) : (
+                              filtered.map((option, index) => {
+                                  const isSelected = option.value === value;
+                                  const isHighlighted =
+                                      index === highlightedIndex;
+                                  const optCls = [
+                                      'dhis2-single-select__option',
+                                      isSelected &&
+                                          'dhis2-single-select__option--selected',
+                                      isHighlighted &&
+                                          'dhis2-single-select__option--highlighted',
+                                      option.disabled &&
+                                          'dhis2-single-select__option--disabled',
+                                  ]
+                                      .filter(Boolean)
+                                      .join(' ');
+
+                                  return (
+                                      <li
+                                          key={option.value}
+                                          className={optCls}
+                                          role="option"
+                                          aria-selected={isSelected}
+                                          onMouseEnter={() =>
+                                              setHighlightedIndex(index)
+                                          }
+                                          onMouseLeave={() =>
+                                              setHighlightedIndex(-1)
+                                          }
+                                          onClick={() => {
+                                              selectOption(option.value);
+                                          }}
+                                      >
+                                          <CheckIcon visible={isSelected} />
+                                          {option.label}
+                                      </li>
+                                  );
+                              })
+                          )}
+                      </ul>
+                  </div>,
+                  portalTarget,
+              )
+            : null;
 
     /* ── Render ── */
     return (
@@ -364,8 +409,6 @@ export function SingleSelect({
             onBlur={handleContainerBlur}
             onKeyDown={handleKeyDown}
         >
-
-            {/* Trigger button */}
             <button
                 ref={triggerRef}
                 type="button"
@@ -388,10 +431,8 @@ export function SingleSelect({
                 </span>
             </button>
 
-            {/* Dropdown rendered via portal */}
             {dropdownMenu}
 
-            {/* Helper / Error text */}
             {error && errorText && (
                 <p className="dhis2-single-select__error-text">{errorText}</p>
             )}

--- a/src/components/marks/marksSelect/SimpleSelectField.tsx
+++ b/src/components/marks/marksSelect/SimpleSelectField.tsx
@@ -1,0 +1,403 @@
+import {
+    useState,
+    useRef,
+    useEffect,
+    useCallback,
+    useMemo,
+    useLayoutEffect,
+    type FocusEvent,
+    type KeyboardEvent,
+} from 'react';
+import { createPortal } from 'react-dom';
+import './SingleSelect.css';
+import { CheckIcon, ChevronIcon, Error } from '../customIcons/customIcons';
+import { SingleSelectProps } from 'src/types/fieldType';
+
+export function SingleSelect({
+    id,
+    value = '',
+    placeholder = '',
+    options,
+    filterable = true,
+    filterPlaceholder = 'Type to filter options',
+    disabled = false,
+    dense = false,
+    error = false,
+    errorText,
+    success,
+    helperText,
+    noMatchText = 'No options found',
+    tabIndex = 0,
+    handleChange,
+    handleBlur,
+}: SingleSelectProps) {
+    console.log(error,
+        errorText,
+        helperText,)
+    /* ── State ── */
+    const [open, setOpen] = useState(false);
+    const [filter, setFilter] = useState('');
+    const [highlightedIndex, setHighlightedIndex] = useState(-1);
+    const [menuStyle, setMenuStyle] = useState<React.CSSProperties>({});
+
+    /* ── Refs ── */
+    const containerRef = useRef<HTMLDivElement>(null);
+    const triggerRef = useRef<HTMLButtonElement>(null);
+    const searchRef = useRef<HTMLInputElement>(null);
+    const optionsRef = useRef<HTMLUListElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
+    const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    /* ── Filtered options ── */
+    const filtered = useMemo(() => {
+        if (!filter) return options;
+        const lower = filter.toLowerCase();
+        return options.filter((o) => o.label.toLowerCase().includes(lower));
+    }, [options, filter]);
+
+    /* ── Selected label ── */
+    const selectedLabel = useMemo(
+        () => options.find((o) => o.value === value)?.label ?? '',
+        [options, value],
+    );
+
+    /* ── Calculate menu position ── */
+    const updateMenuPosition = useCallback(() => {
+        if (!triggerRef.current) return;
+        const rect = triggerRef.current.getBoundingClientRect();
+        setMenuStyle({
+            position: 'fixed',
+            top: rect.bottom + 4,
+            left: rect.left,
+            width: rect.width,
+            zIndex: 9999,
+        });
+    }, []);
+
+    /* ── Open / Close helpers ── */
+    const openMenu = useCallback(() => {
+        if (disabled) return;
+        setOpen(true);
+        setFilter('');
+        setHighlightedIndex(-1);
+    }, [disabled]);
+
+    const closeMenu = useCallback(() => {
+        setOpen(false);
+        setFilter('');
+        setHighlightedIndex(-1);
+    }, []);
+
+    /* ── Select an option ── */
+    const selectOption = (value: string) => {
+        handleChange?.(value);
+        triggerRef.current?.focus();
+    }
+
+    /* ── Focus management for handleBlur ── */
+    const handleContainerBlur = useCallback(
+        (e: FocusEvent<HTMLDivElement>) => {
+            if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+
+            blurTimeoutRef.current = setTimeout(() => {
+                const activeEl = document.activeElement;
+                const inContainer =
+                    containerRef.current?.contains(activeEl) ?? false;
+                const inMenu = menuRef.current?.contains(activeEl) ?? false;
+
+                if (!inContainer && !inMenu) {
+                    handleBlur?.();
+                }
+            }, 0);
+        },
+        [handleBlur],
+    );
+
+    /* ── Portal menu blur / focus ── */
+    const handleMenuBlur = useCallback(
+        (e: FocusEvent<HTMLDivElement>) => {
+            if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+
+            blurTimeoutRef.current = setTimeout(() => {
+                const activeEl = document.activeElement;
+                const inContainer =
+                    containerRef.current?.contains(activeEl) ?? false;
+                const inMenu = menuRef.current?.contains(activeEl) ?? false;
+
+                if (!inContainer && !inMenu) {
+                    closeMenu();
+                    handleBlur?.();
+                }
+            }, 0);
+        },
+        [closeMenu, handleBlur],
+    );
+
+    const handleMenuFocus = useCallback(() => {
+        if (blurTimeoutRef.current) clearTimeout(blurTimeoutRef.current);
+    }, []);
+
+    /* ── Click outside ── */
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: MouseEvent) => {
+            const target = e.target as Node;
+            const inContainer = containerRef.current?.contains(target) ?? false;
+            const inMenu = menuRef.current?.contains(target) ?? false;
+
+            if (!inContainer && !inMenu) {
+                closeMenu();
+            }
+        };
+        document.addEventListener('mousedown', handler);
+        return () => document.removeEventListener('mousedown', handler);
+    }, [open, closeMenu]);
+
+    /* ── Position menu on open and reposition on scroll/resize ── */
+    useLayoutEffect(() => {
+        if (!open) return;
+        updateMenuPosition();
+    }, [open, updateMenuPosition]);
+
+    useEffect(() => {
+        if (!open) return;
+        const reposition = () => updateMenuPosition();
+        window.addEventListener('scroll', reposition, true);
+        window.addEventListener('resize', reposition);
+        return () => {
+            window.removeEventListener('scroll', reposition, true);
+            window.removeEventListener('resize', reposition);
+        };
+    }, [open, updateMenuPosition]);
+
+    /* ── Focus search on open ── */
+    useEffect(() => {
+        if (open && filterable) {
+            requestAnimationFrame(() => searchRef.current?.focus());
+        }
+    }, [open, filterable]);
+
+    /* ── Scroll highlighted option into view ── */
+    useEffect(() => {
+        if (highlightedIndex < 0 || !optionsRef.current) return;
+        const items = optionsRef.current.querySelectorAll(
+            '.dhis2-single-select__option',
+        );
+        items[highlightedIndex]?.scrollIntoView({ block: 'nearest' });
+    }, [highlightedIndex]);
+
+    /* ── Keyboard navigation ── */
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (disabled) return;
+
+            switch (e.key) {
+                case 'ArrowDown': {
+                    e.preventDefault();
+                    if (!open) {
+                        openMenu();
+                        return;
+                    }
+                    setHighlightedIndex((prev) => {
+                        let next = prev + 1;
+                        while (next < filtered.length && filtered[next].disabled) next++;
+                        return next < filtered.length ? next : prev;
+                    });
+                    break;
+                }
+                case 'ArrowUp': {
+                    e.preventDefault();
+                    if (!open) {
+                        openMenu();
+                        return;
+                    }
+                    setHighlightedIndex((prev) => {
+                        let next = prev - 1;
+                        while (next >= 0 && filtered[next].disabled) next--;
+                        return next >= 0 ? next : prev;
+                    });
+                    break;
+                }
+                case 'Enter':
+                case ' ': {
+                    if (!open) {
+                        e.preventDefault();
+                        openMenu();
+                    } else if (highlightedIndex >= 0 && filtered[highlightedIndex]) {
+                        e.preventDefault();
+                        if (!filtered[highlightedIndex].disabled) {
+                            selectOption(filtered[highlightedIndex].value);
+                        }
+                    }
+                    break;
+                }
+                case 'Escape': {
+                    e.preventDefault();
+                    closeMenu();
+                    triggerRef.current?.focus();
+                    break;
+                }
+                case 'Tab': {
+                    if (open) closeMenu();
+                    break;
+                }
+                case 'Home': {
+                    if (open) {
+                        e.preventDefault();
+                        setHighlightedIndex(0);
+                    }
+                    break;
+                }
+                case 'End': {
+                    if (open) {
+                        e.preventDefault();
+                        setHighlightedIndex(filtered.length - 1);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        },
+        [disabled, open, openMenu, closeMenu, filtered, highlightedIndex, selectOption],
+    );
+
+    /* ── Build class names ── */
+    const rootCls = [
+        'dhis2-single-select',
+        dense && 'dhis2-single-select--dense',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    const triggerCls = [
+        'dhis2-single-select__trigger',
+        open && 'dhis2-single-select__trigger--open',
+        error && 'dhis2-single-select__trigger--error',
+        success && 'dhis2-single-select__trigger--success',
+        disabled && 'dhis2-single-select__trigger--disabled',
+    ]
+        .filter(Boolean)
+        .join(' ');
+
+    /* ── Dropdown menu rendered via Portal ── */
+    const dropdownMenu = open
+        ? createPortal(
+            <div
+                ref={menuRef}
+                className={`dhis2-single-select__menu${dense ? ' dhis2-single-select__menu--dense' : ''}`}
+                style={menuStyle}
+                role="presentation"
+                onBlur={handleMenuBlur}
+                onFocus={handleMenuFocus}
+                onKeyDown={handleKeyDown}
+            >
+                {/* Search input */}
+                {filterable && (
+                    <div className="dhis2-single-select__search">
+                        <input
+                            ref={searchRef}
+                            type="text"
+                            className="dhis2-single-select__search-input"
+                            placeholder={filterPlaceholder}
+                            value={filter}
+                            onChange={(e) => {
+                                setFilter(e.target.value);
+                                setHighlightedIndex(-1);
+                            }}
+                            autoComplete="off"
+                        />
+                    </div>
+                )}
+
+                {/* Options list */}
+                <ul
+                    ref={optionsRef}
+                    className="dhis2-single-select__options"
+                    role="listbox"
+                >
+                    {filtered.length === 0 ? (
+                        <li className="dhis2-single-select__empty">{noMatchText}</li>
+                    ) : (
+                        filtered.map((option, index) => {
+                            const isSelected = option.value === value;
+                            const isHighlighted = index === highlightedIndex;
+                            const optCls = [
+                                'dhis2-single-select__option',
+                                isSelected && 'dhis2-single-select__option--selected',
+                                isHighlighted && 'dhis2-single-select__option--highlighted',
+                                option.disabled && 'dhis2-single-select__option--disabled',
+                            ]
+                                .filter(Boolean)
+                                .join(' ');
+
+                            return (
+                                <li
+                                    key={option.value}
+                                    className={optCls}
+                                    role="option"
+                                    aria-selected={isSelected}
+                                    onMouseEnter={() => setHighlightedIndex(index)}
+                                    onMouseLeave={() => setHighlightedIndex(-1)}
+                                    onClick={() => {
+                                        selectOption(option.value);
+                                    }}
+                                >
+                                    <CheckIcon visible={isSelected} />
+                                    {option.label}
+                                </li>
+                            );
+                        })
+                    )}
+                </ul>
+            </div>,
+            document.body,
+        )
+        : null;
+
+    /* ── Render ── */
+    return (
+        <div
+            ref={containerRef}
+            className={rootCls}
+            id={id}
+            onBlur={handleContainerBlur}
+            onKeyDown={handleKeyDown}
+        >
+
+            {/* Trigger button */}
+            <button
+                ref={triggerRef}
+                type="button"
+                className={triggerCls}
+                tabIndex={tabIndex}
+                disabled={disabled}
+                aria-haspopup="listbox"
+                aria-expanded={open}
+                onClick={() => (open ? closeMenu() : openMenu())}
+            >
+                <span
+                    className={`dhis2-single-select__trigger-content${!value ? ' dhis2-single-select__placeholder' : ''}`}
+                >
+                    {value ? selectedLabel : placeholder}
+                </span>
+
+                {error && <Error />}
+                <span className="dhis2-single-select__actions">
+                    <ChevronIcon open={open} />
+                </span>
+            </button>
+
+            {/* Dropdown rendered via portal */}
+            {dropdownMenu}
+
+            {/* Helper / Error text */}
+            {error && errorText && (
+                <p className="dhis2-single-select__error-text">{errorText}</p>
+            )}
+            {!error && helperText && (
+                <p className="dhis2-single-select__helper">{helperText}</p>
+            )}
+        </div>
+    );
+}

--- a/src/components/marks/marksSelect/SingleSelect.css
+++ b/src/components/marks/marksSelect/SingleSelect.css
@@ -1,0 +1,284 @@
+/* ── DHIS2-style SingleSelect ── */
+
+.dhis2-single-select {
+  position: relative;
+  width: 100%;
+  font-family: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px;
+  /* Prevent the component from expanding parent table rows */
+  vertical-align: top;
+}
+
+/* ── Label ── */
+.dhis2-single-select__label {
+  display: block;
+  margin-bottom: 4px;
+  font-size: 14px;
+  font-weight: 400;
+  color: #212934;
+  line-height: 19px;
+}
+
+.dhis2-single-select__label--required::after {
+  content: ' *';
+  color: #d32f2f;
+}
+
+/* ── Trigger Button ── */
+.dhis2-single-select__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 12px;
+  background-color: #fff;
+  border: 1px solid #a0adba;
+  border-radius: 3px;
+  cursor: pointer;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  text-align: left;
+  /* gap: 8px; */
+}
+
+.dhis2-single-select__trigger:hover {
+  border-color: #6e7a8a;
+}
+
+.dhis2-single-select__trigger:focus,
+.dhis2-single-select__trigger--open {
+  border-color: #0d47a1;
+  box-shadow: 0 0 0 3px rgba(13, 71, 161, 0.12);
+}
+
+.dhis2-single-select__trigger--error {
+  border-color: #d32f2f;
+}
+
+.dhis2-single-select__trigger--error:focus,
+.dhis2-single-select__trigger--error.dhis2-single-select__trigger--open {
+  border-color: #d32f2f;
+  box-shadow: 0 0 0 3px rgba(211, 47, 47, 0.12);
+}
+
+.dhis2-single-select__trigger--disabled {
+  background-color: #f3f5f7;
+  border-color: #d5dde5;
+  color: #a0adba;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+/* ── Trigger Content ── */
+.dhis2-single-select__trigger-content {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  color: #212934;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.dhis2-single-select__placeholder {
+  color: #6e7a8a;
+}
+
+/* ── Action Icons ── */
+.dhis2-single-select__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.dhis2-single-select__clear-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #6e7a8a;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.dhis2-single-select__clear-btn:hover {
+  background-color: #f3f5f7;
+  color: #212934;
+}
+
+.dhis2-single-select__arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  color: #6e7a8a;
+  transition: transform 0.2s ease;
+}
+
+.dhis2-single-select__arrow--open {
+  transform: rotate(180deg);
+}
+
+/* ── Dropdown Menu (rendered via Portal at document.body) ── */
+.dhis2-single-select__menu {
+  /* position is set via inline style (fixed) */
+  background-color: #fff;
+  border: 1px solid #d5dde5;
+  border-radius: 3px;
+  box-shadow: 0 4px 16px rgba(33, 41, 52, 0.12), 0 0 1px rgba(33, 41, 52, 0.18);
+  overflow: hidden;
+  animation: dhis2-select-slide-down 0.15s ease-out;
+}
+
+@keyframes dhis2-select-slide-down {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Search Input ── */
+.dhis2-single-select__search {
+  padding: 8px;
+  border-bottom: 1px solid #e8edf2;
+}
+
+.dhis2-single-select__search-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #a0adba;
+  border-radius: 3px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  color: #212934;
+  background-color: #fff;
+}
+
+.dhis2-single-select__search-input::placeholder {
+  color: #a0adba;
+}
+
+.dhis2-single-select__search-input:focus {
+  border-color: #0d47a1;
+  box-shadow: 0 0 0 3px rgba(13, 71, 161, 0.12);
+}
+
+/* ── Options List ── */
+.dhis2-single-select__options {
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 4px 0;
+  list-style: none;
+  margin: 0;
+}
+
+.dhis2-single-select__options::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dhis2-single-select__options::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dhis2-single-select__options::-webkit-scrollbar-thumb {
+  background-color: #c4ced8;
+  border-radius: 3px;
+}
+
+/* ── Option Item ── */
+.dhis2-single-select__option {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 14px;
+  color: #212934;
+  line-height: 18px;
+  transition: background-color 0.1s ease;
+  gap: 8px;
+}
+
+.dhis2-single-select__option:hover,
+.dhis2-single-select__option--highlighted {
+  background-color: #f3f5f7;
+}
+
+.dhis2-single-select__option--selected {
+  background-color: #e8f4fd;
+  color: #0d47a1;
+  font-weight: 500;
+}
+
+.dhis2-single-select__option--selected:hover {
+  background-color: #d4ecfa;
+}
+
+.dhis2-single-select__option-check {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  color: #0d47a1;
+}
+
+.dhis2-single-select__option-check--hidden {
+  visibility: hidden;
+}
+
+/* ── Empty State ── */
+.dhis2-single-select__empty {
+  padding: 16px 12px;
+  text-align: center;
+  color: #6e7a8a;
+  font-size: 14px;
+  font-style: italic;
+}
+
+/* ── Helper / Error Text ── */
+.dhis2-single-select__helper {
+  margin-top: 4px;
+  font-size: 12px;
+  color: #6e7a8a;
+  line-height: 16px;
+}
+
+.dhis2-single-select__trigger--success{
+   border:solid 2px #2aa643;
+}
+
+.dhis2-single-select__error-text {
+  margin-bottom: 0px;
+  font-size: 10px;
+  color: #d32f2f;
+  line-height: 16px;
+}
+
+/* ── Dense variant ── */
+.dhis2-single-select--dense .dhis2-single-select__trigger {
+  min-height: 32px;
+  padding: 4px 8px;
+  font-size: 13px;
+}
+
+.dhis2-single-select--dense .dhis2-single-select__option {
+  padding: 6px 8px;
+  font-size: 13px;
+}
+
+.dhis2-single-select__option-warning {
+  flex-shrink: 0;
+  color: #d32f2f;
+  margin-right: 8px;
+}
+

--- a/src/components/marks/performanceFieldsMapping.tsx
+++ b/src/components/marks/performanceFieldsMapping.tsx
@@ -1,0 +1,19 @@
+import { SimpleFieldProps } from "../../types/fieldType";
+import SimpleField from "./SimpleField";
+import { SingleSelect } from "./marksSelect/SimpleSelectField";
+
+export function performanceFieldsMapping(props: SimpleFieldProps & { fieldType: string, options?: any }) {
+    const { fieldType, options, ...rest } = props
+
+    switch (fieldType) {
+        case 'LIST': return (
+            <SingleSelect {...rest} errorText={rest?.content} options={options} />
+        )
+        default: return (
+            <SimpleField
+                {...rest as any}
+            />
+        )
+
+    }
+}

--- a/src/types/fieldType.ts
+++ b/src/types/fieldType.ts
@@ -1,0 +1,62 @@
+export type SimpleFieldProps = {
+    field: any;
+    error?: boolean;
+    content: string;
+    loading: boolean;
+    warning?: boolean;
+    success?: boolean;
+    visible?: boolean;
+    disabled?: boolean;
+    value: string | number;
+    handleBlur: () => void;
+    handleChange: (e: React.ChangeEvent<HTMLInputElement> | string | number | null | undefined) => void;
+};
+
+
+
+/* ────────────────────────────── Types ────────────────────────────── */
+
+export interface SingleSelectOption {
+    label: string;
+    value: string;
+    disabled?: boolean;
+}
+
+export interface SingleSelectProps {
+    /** Unique HTML id */
+    id?: string;
+    /** Label displayed above the select */
+    label?: string;
+    /** Currently selected value (controlled) */
+    value?: string | number;
+    /** Placeholder when nothing is selected */
+    placeholder?: string;
+    /** Array of options */
+    options: SingleSelectOption[];
+    /** Enable the search/filter input inside the dropdown */
+    filterable?: boolean;
+    /** Placeholder text inside the search input */
+    filterPlaceholder?: string;
+    /** Disable the entire component */
+    disabled?: boolean;
+    /** Use the dense (compact) variant */
+    dense?: boolean;
+    /** Mark as required (adds * to label) */
+    required?: boolean;
+    /** Display an error state */
+    error?: boolean;
+    /** Error message displayed below the select */
+    errorText?: string;
+    /** Helper text displayed below the select */
+    helperText?: string;
+    /** Text shown when the filter produces no results */
+    noMatchText?: string;
+    /** Tab index */
+    tabIndex?: number;
+    /** Called when the selected value changes */
+    handleChange?: (value?: string) => void;
+    /** Called when the component loses focus */
+    handleBlur?: () => void;
+    /** Called when the component receives focus */
+    success?: boolean
+}

--- a/src/utils/fields/includeFields.ts
+++ b/src/utils/fields/includeFields.ts
@@ -42,7 +42,7 @@ export const includeFields = (props: IncludeFieldsProps) => {
     const modifiedRowsData = cloneDeep(rowsData);
 
     // Transform the rows immutably using map
-    const newRowsData = modifiedRowsData.map((row, i) => {
+    const newRowsData = modifiedRowsData.map((row: any, i: number) => {
         // Create a new row object to avoid mutating the cloned row
         const newRow = { ...row };
 


### PR DESCRIPTION
Introduce a new mapping component to handle LIST field types with a custom SingleSelect dropdown. This replaces the generic SimpleField for LIST types, providing proper option selection UI.

- Create performanceFieldsMapping to conditionally render fields based on valueType
- Implement SingleSelect component with filtering, keyboard navigation, and portal rendering
- Add comprehensive type definitions for field components
- Include custom icons and CSS for DHIS2-style select component
- Update FieldsPerformance to use the new mapping system
- Add explicit type annotations to includeFields utility