### PR TITLE
fix: pass baseUrl prop to Performance and EnrollmentActionsButtons

### DIFF
--- a/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
+++ b/src/components/enrollmentButtons/EnrollmentActionsButtons.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { Form } from 'react-final-form';
 import ShowStats from '../stats/showStats';
 import { Tooltip } from '@mui/material';
-import { useConfig } from '@dhis2/app-runtime';
 import styles from './enrollmentActionsButtons.module.css'
 import { Button, ButtonStrip, IconUserGroup16, IconEdit24 } from "@dhis2/ui";
 import { useCheckFilters, useGetSectionTypeLabel, useShowAlerts, useUrlParams } from 'dhis2-semis-functions';
@@ -11,8 +10,7 @@ import EditOffIcon from '@mui/icons-material/EditOff';
 import useGetSelectedKeys from '../../hooks/config/useGetSelectedKeys';
 import { D2I18n } from 'dhis2-semis-types';
 
-function EnrollmentActionsButtons({ setEditionMode, editionMode, i18n }: { i18n: D2I18n, setEditionMode: (editionMode: boolean) => void, editionMode: boolean }) {
-    const { baseUrl } = useConfig()
+function EnrollmentActionsButtons({ setEditionMode, editionMode, i18n, baseUrl }: { i18n: D2I18n, setEditionMode: (editionMode: boolean) => void, editionMode: boolean, baseUrl: string }) {
     const { urlParameters } = useUrlParams();
     const { school: orgUnit, class: section, grade, academicYear } = urlParameters;
     const { sectionName } = useGetSectionTypeLabel();

--- a/src/components/routes/Router.tsx
+++ b/src/components/routes/Router.tsx
@@ -8,7 +8,7 @@ export default function Router({ i18n, baseUrl }: { i18n: D2I18n; baseUrl: strin
     return (
         <Routes>
             <Route path='/' element={<WithHeaderBarLayout baseUrl={baseUrl} />}>
-                <Route key={'performance'} path={'/'} element={<Performance i18n={i18n} />} />
+                <Route key={'performance'} path={'/'} element={<Performance i18n={i18n} baseUrl={baseUrl} />} />
             </Route>
         </Routes>
     );

--- a/src/pages/performance/performance.tsx
+++ b/src/pages/performance/performance.tsx
@@ -19,7 +19,7 @@ interface FilteredStage {
   label: string;
 }
 
-export default function Performance({ i18n }: { i18n: D2I18n }) {
+export default function Performance({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: string }) {
   const { program, dataStoreData } = useGetSelectedKeys();
   const { viewPortWidth } = useViewPortWidth();
   const { urlParameters, add } = useUrlParams();
@@ -146,7 +146,7 @@ export default function Performance({ i18n }: { i18n: D2I18n }) {
               defaultFilterNumber={5}
               filterState={filterState}
               loading={loading}
-              rightElements={<EnrollmentActionsButtons i18n={i18n} setEditionMode={setEditionMode} editionMode={editionMode} />}
+              rightElements={<EnrollmentActionsButtons i18n={i18n} setEditionMode={setEditionMode} editionMode={editionMode} baseUrl={baseUrl} />}
               setFilterState={setFilterState}
               pagination={pagination}
               setPagination={setPagination}


### PR DESCRIPTION
The baseUrl prop was not being passed down from the Router to the Performance component and subsequently to the EnrollmentActionsButtons component. This caused the EnrollmentActionsButtons component to fail because it was previously relying on the useConfig hook to get the baseUrl. Now the baseUrl is explicitly passed as a prop through the component hierarchy for better reliability and testability.