### PR TITLE
fix(marks): improve saving error handling and stage label display

### DIFF
--- a/src/components/marks/FieldsPerformance.tsx
+++ b/src/components/marks/FieldsPerformance.tsx
@@ -1,10 +1,8 @@
 import { format } from 'date-fns';
-import { useRecoilState } from 'recoil';
 import { useEffect, useMemo, useState } from 'react';
 import useSaveMarks from '../../hooks/marks/useSaveMarks';
-import { EnrollmentStatus, TableDataRefetch } from 'dhis2-semis-types';
-import { formatMarksToSave } from '../../utils/marks/formatMarksToPost';
-import { RulesEngine, useUploadEvents, useUrlParams } from 'dhis2-semis-functions';
+import { EnrollmentStatus } from 'dhis2-semis-types';
+import { RulesEngine, useShowAlerts, useUploadEvents, useUrlParams } from 'dhis2-semis-functions';
 import { performanceFieldsMapping } from './performanceFieldsMapping';
 
 interface valueType extends Record<string, any> {
@@ -31,7 +29,7 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
     const [values, setValues] = useState({ ...value })
 
     const { uploadValues } = useUploadEvents()
-    const { saveMarks, error, loading, success } = useSaveMarks()
+    const { saveMarks, error, loading, success, setError } = useSaveMarks()
 
     const memoizedValues = useMemo(() => values, [JSON.stringify(values)]);
     const memoizedDataElements = useMemo(() => [dataElements], [JSON.stringify(dataElements)]);
@@ -41,7 +39,7 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
     })
 
     const [newMark, setNewMark] = useState(updatedVariables[0].value)
-    const [refetch, setRefetch] = useRecoilState(TableDataRefetch);
+    const { hide, show } = useShowAlerts()
 
     useEffect(() => {
         runRulesEngine({ overrideValues: memoizedValues, overrideVariables: memoizedDataElements as any })
@@ -80,9 +78,18 @@ export default function FieldsPerformance(props: FieldsPerformancePros) {
             }
 
             await uploadValues(data, "COMMIT", "CREATE_AND_UPDATE")
-                .then(() => setRefetch(!refetch))
-        }
-        else {
+                .then((resp: any) => {
+                    if (resp?.stats?.ignored > 0) {
+                        setNewMark(null)
+                        setError(true)
+                        show({
+                            message: `Could not save the marks: ${resp?.validationReport?.errorReports?.[0]?.message}`,
+                            type: { critical: true }
+                        });
+                        setTimeout(() => { hide; setError(false); }, 3000);
+                    }
+                })
+        } else {
             const marks = {
                 events: [{
                     dataValues: [{

--- a/src/hooks/marks/useSaveMarks.ts
+++ b/src/hooks/marks/useSaveMarks.ts
@@ -13,8 +13,6 @@ const POST_DATA_VALUE: any = {
     data: ({ data }: any) => data
 }
 
-type saveMarksType = { id: string, data: object }
-
 export default function useSaveMarks() {
     const engine = useDataEngine()
     const [data, setData] = useState()
@@ -31,10 +29,6 @@ export default function useSaveMarks() {
                 setData(resp);
                 setSuccess(true);
                 setLoading(false);
-                // show({
-                //     message: "Marks saved successfully",
-                //     type: { success: true }
-                // });
                 setTimeout(() => { hide; setSuccess(false) }, 3000);
             }),
             onError: ((error) => {
@@ -49,5 +43,5 @@ export default function useSaveMarks() {
         })
     }
 
-    return { loading, saveMarks, saved: data, error, success }
+    return { loading, saveMarks, saved: data, error, success, setError }
 }

--- a/src/pages/performance/performance.tsx
+++ b/src/pages/performance/performance.tsx
@@ -94,7 +94,9 @@ export default function Performance({ i18n, baseUrl }: { i18n: D2I18n, baseUrl: 
   }, [tableData])
 
   useEffect(() => {
-    setSelected({ id: programStage, label: "" })
+    const selectedStage = program?.programStages?.find((stage) => stage.id === programStage);
+
+    setSelected({ id: programStage, label: selectedStage?.displayName! })
   }, [academicYear, grade, section])
 
   function filterProgramStages(programData: any, filterData: any): FilteredStage[] {


### PR DESCRIPTION
- Display program stage display name instead of empty label in performance page
- Enhance marks saving to show validation errors from upload response
- Remove unused imports and refactor error state management in useSaveMarks hook
- Replace Recoil refetch with alert-based error feedback in FieldsPerformance